### PR TITLE
fix: add ASSETS binding to wrangler.toml for static file serving

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,12 @@ compatibility_date = "2025-11-07"
 main = "dist/_worker.js"
 compatibility_flags = ["nodejs_compat"]
 
+# Static assets configuration
+# Serve static files from the dist directory
+[assets]
+directory = "dist"
+binding = "ASSETS"
+
 # KV Namespace for session storage (required by @astrojs/cloudflare)
 # KV Namespace: rio-backend-kv
 [[kv_namespaces]]


### PR DESCRIPTION
Fixed deployment error "Cannot read properties of undefined (reading 'fetch')" that was preventing static assets from being served on Cloudflare Workers.

## Issue
All static assets (favicons, CSS, JS, service workers) were failing with:
- Cannot read properties of undefined (reading 'fetch')
- Affected files: favicon.ico, *.png, *.css, *.js, site.webmanifest

## Root Cause
The Astro Cloudflare adapter expects an ASSETS binding in wrangler.toml to serve static files, but this binding was missing from the configuration.

## Solution
Added [assets] configuration to wrangler.toml:
- directory = "dist" (points to Astro build output)
- binding = "ASSETS" (makes assets available via env.ASSETS.fetch())

## Verification
- ✅ Build succeeds
- ✅ All static assets present in dist/
- ✅ ASSETS binding now available in Cloudflare Workers runtime

This resolves all static asset serving errors on deployment.