### PR TITLE
fix: properly configure passthroughImageService for Cloudflare Workers

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { defineConfig } from "astro/config";
+import { defineConfig, passthroughImageService } from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
 
 import icon from "astro-icon";
@@ -64,13 +64,10 @@ export default defineConfig({
   integrations: [icon(), partytown(), sitemap(), markdoc(), mdx(), react()],
 
   image: {
-    service: {
-      entrypoint: "astro/assets/services/noop",
-    },
+    service: passthroughImageService(),
   },
 
   adapter: cloudflare({
-    imageService: "noop",
     platformProxy: {
       enabled: true,
     },

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { defineConfig } from "astro/config";
+import { defineConfig, passthroughImageService } from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
 
 import icon from "astro-icon";
@@ -61,11 +61,10 @@ export default defineConfig({
   integrations: [icon(), partytown(), sitemap(), markdoc(), mdx(), react()],
 
   image: {
-    responsiveStyles: true,
+    service: passthroughImageService(),
   },
 
   adapter: cloudflare({
-    imageService: "passthrough",
     platformProxy: {
       enabled: true,
     },

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -30,6 +30,9 @@ export default defineConfig({
           }
         : undefined,
     },
+    ssr: {
+      external: ["node:fs", "node:path", "node:url", "node:buffer", "node:stream"],
+    },
   },
 
   markdown: {
@@ -65,6 +68,7 @@ export default defineConfig({
   },
 
   adapter: cloudflare({
+    imageService: "passthrough",
     platformProxy: {
       enabled: true,
     },

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { defineConfig, passthroughImageService } from "astro/config";
+import { defineConfig } from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
 
 import icon from "astro-icon";
@@ -64,11 +64,13 @@ export default defineConfig({
   integrations: [icon(), partytown(), sitemap(), markdoc(), mdx(), react()],
 
   image: {
-    service: passthroughImageService(),
+    service: {
+      entrypoint: "astro/assets/services/noop",
+    },
   },
 
   adapter: cloudflare({
-    imageService: "passthrough",
+    imageService: "noop",
     platformProxy: {
       enabled: true,
     },


### PR DESCRIPTION
The issue was that imageService: "passthrough" was not properly configured. The /_image endpoint was expecting a service with a transform() method, but the passthrough service doesn't have one, causing the error: "Configured image service is not a local service"

This resulted in broken image URLs like:
https://web.riomyid.workers.dev/_image?href=%2F_astro%2Fme-avatar.DIg4xMhG.png

Solution:
- Import passthroughImageService from "astro/config"
- Configure it properly: image: { service: passthroughImageService() }
- Remove imageService config from adapter (not needed)

Now the /_image endpoint acts as a simple proxy/redirect to static assets in /_astro/, which are served directly by Cloudflare Workers ASSETS binding.

Changes:
- Import passthroughImageService from astro/config
- Move image service config to top-level image.service property
- Remove imageService from cloudflare adapter config